### PR TITLE
Update migrations

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.4.18;
 
 contract Migrations {
-  address owner;
-  uint256 last_completed_migration;
+  address public owner;
+  uint256 public last_completed_migration;
 
   modifier restricted() {
     if (msg.sender == owner) _;
@@ -19,13 +19,5 @@ contract Migrations {
   function upgrade(address _newAddress) public restricted {
     Migrations upgraded = Migrations(_newAddress);
     upgraded.setCompleted(last_completed_migration);
-  }
-
-  function getOwner() public constant returns (address) {
-    return owner;
-  }
-
-  function getLastCompletedMigration() public constant returns (uint256) {
-    return last_completed_migration;
   }
 }

--- a/jsroutines/jsconfig/initConfig.js
+++ b/jsroutines/jsconfig/initConfig.js
@@ -1,0 +1,13 @@
+const TxConfig = require('./TxConfig');
+const DeployConfig = require('./DeployConfig');
+
+module.exports = function initConfig(web3, deployer, network, accounts) {
+  global.console.log(`  Accounts: ${accounts}`);
+  global.console.log(`  Network:  ${network}`);
+
+  TxConfig.setWeb3(web3);
+  TxConfig.setNetworkType(network);
+
+  DeployConfig.setDeployer(deployer);
+  DeployConfig.setAccounts(accounts);
+};

--- a/jsroutines/migrations/index.js
+++ b/jsroutines/migrations/index.js
@@ -34,17 +34,17 @@ export const verifyMigrationNumber2 = async () => {
 
 const executeMigrationNumber3 = async () => {
   const JNTControllerInstance = await JNTController.deployed();
-  const JNTControllerAddress = await JNTControllerInstance.address;
+  const JNTControllerAddress = JNTControllerInstance.address;
 
   await CrydrInit.initCrydr(jUSDStorage, jUSDController, jUSDViewERC20, 'erc20');
   const jUSDControllerInstance = await jUSDController.deployed();
-  const jUSDControllerAddress = await jUSDControllerInstance.address;
+  const jUSDControllerAddress = jUSDControllerInstance.address;
   await CrydrControllerInit.configureJntPayableService(jUSDControllerAddress, JNTControllerAddress);
   await CrydrInit.upauseCrydrControllerAndStorage(jUSDStorage, jUSDController);
 
   await CrydrInit.initCrydr(jKRWStorage, jKRWController, jKRWViewERC20, 'erc20');
   const jKRWControllerInstance = await jKRWController.deployed();
-  const jKRWControllerAddress = await jKRWControllerInstance.address;
+  const jKRWControllerAddress = jKRWControllerInstance.address;
   await CrydrControllerInit.configureJntPayableService(jKRWControllerAddress, JNTControllerAddress);
   await CrydrInit.upauseCrydrControllerAndStorage(jKRWStorage, jKRWController);
 };

--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -1,7 +1,20 @@
+const TxConfig = require('../jsroutines/jsconfig/TxConfig');
+const DeployConfig = require('../jsroutines/jsconfig/DeployConfig');
+
+const Migrations = artifacts.require('./Migrations.sol');
+
 global.artifacts = artifacts; // eslint-disable-line no-undef
 
-const Migrations = global.artifacts.require('./Migrations.sol');
+module.exports = (deployer, network, accounts) => {
+  global.console.log('  Start migrations');
+  global.console.log(`  Accounts: ${accounts}`);
+  global.console.log(`  Network:  ${network}`);
 
-module.exports = (deployer) => {
+  TxConfig.setWeb3(web3); // eslint-disable-line no-undef
+  TxConfig.setNetworkType(network);
+
+  DeployConfig.setDeployer(deployer);
+  DeployConfig.setAccounts(accounts);
+
   deployer.deploy(Migrations);
 };

--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -1,20 +1,13 @@
-const TxConfig = require('../jsroutines/jsconfig/TxConfig');
-const DeployConfig = require('../jsroutines/jsconfig/DeployConfig');
-
-const Migrations = artifacts.require('./Migrations.sol');
+const initConfig = require('../jsroutines/jsconfig/initConfig');
 
 global.artifacts = artifacts; // eslint-disable-line no-undef
 
+const Migrations = global.artifacts.require('./Migrations.sol');
+
 module.exports = (deployer, network, accounts) => {
   global.console.log('  Start migrations');
-  global.console.log(`  Accounts: ${accounts}`);
-  global.console.log(`  Network:  ${network}`);
 
-  TxConfig.setWeb3(web3); // eslint-disable-line no-undef
-  TxConfig.setNetworkType(network);
-
-  DeployConfig.setDeployer(deployer);
-  DeployConfig.setAccounts(accounts);
+  initConfig(web3, deployer, network, accounts); // eslint-disable-line no-undef
 
   deployer.deploy(Migrations);
 };

--- a/migrations/2_deploy_jnt.js
+++ b/migrations/2_deploy_jnt.js
@@ -1,11 +1,15 @@
+const migrations = require('../jsroutines/migrations');
+const initConfig = require('../jsroutines/jsconfig/initConfig');
+
 global.artifacts = artifacts; // eslint-disable-line no-undef
 
-const migrations = require('../jsroutines/migrations');
-
-module.exports = (deployer) => {
+module.exports = (deployer, network, accounts) => {
   global.console.log('  Start migration 2');
 
-  deployer.then(() => migrations.executeMigration(2))
-          .then(() => migrations.verifyMigration(2))
-          .then(() => global.console.log('  Migration 2 finished'));
+  initConfig(web3, deployer, network, accounts); // eslint-disable-line no-undef
+
+  deployer
+    .then(() => migrations.executeMigration(2))
+    .then(() => migrations.verifyMigration(2))
+    .then(() => global.console.log('  Migration 2 finished'));
 };

--- a/migrations/2_deploy_jnt.js
+++ b/migrations/2_deploy_jnt.js
@@ -1,28 +1,11 @@
-require('babel-register');
-require('babel-polyfill');
-
 global.artifacts = artifacts; // eslint-disable-line no-undef
 
-
-const TxConfig = require('../jsroutines/jsconfig/TxConfig');
-const DeployConfig = require('../jsroutines/jsconfig/DeployConfig');
 const migrations = require('../jsroutines/migrations');
 
-
-/* Migration */
-
-module.exports = (deployer, network, accounts) => {
-  global.console.log('  Start migration');
-  global.console.log(`  Accounts: ${accounts}`);
-  global.console.log(`  Network:  ${network}`);
-
-  TxConfig.setWeb3(web3); // eslint-disable-line no-undef
-  TxConfig.setNetworkType(network);
-
-  DeployConfig.setDeployer(deployer);
-  DeployConfig.setAccounts(accounts);
+module.exports = (deployer) => {
+  global.console.log('  Start migration 2');
 
   deployer.then(() => migrations.executeMigration(2))
           .then(() => migrations.verifyMigration(2))
-          .then(() => global.console.log('  Migration finished'));
+          .then(() => global.console.log('  Migration 2 finished'));
 };

--- a/migrations/3_deploy_jcash.js
+++ b/migrations/3_deploy_jcash.js
@@ -1,28 +1,11 @@
-require('babel-register');
-require('babel-polyfill');
-
 global.artifacts = artifacts; // eslint-disable-line no-undef
 
-
-const TxConfig = require('../jsroutines/jsconfig/TxConfig');
-const DeployConfig = require('../jsroutines/jsconfig/DeployConfig');
 const migrations = require('../jsroutines/migrations');
 
-
-/* Migration */
-
-module.exports = (deployer, network, accounts) => {
-  global.console.log('  Start migration');
-  global.console.log(`  Accounts: ${accounts}`);
-  global.console.log(`  Network:  ${network}`);
-
-  TxConfig.setWeb3(web3); // eslint-disable-line no-undef
-  TxConfig.setNetworkType(network);
-
-  DeployConfig.setDeployer(deployer);
-  DeployConfig.setAccounts(accounts);
+module.exports = (deployer) => {
+  global.console.log('  Start migration 3');
 
   deployer.then(() => migrations.executeMigration(3))
           .then(() => migrations.verifyMigration(3))
-          .then(() => global.console.log('  Migration finished'));
+          .then(() => global.console.log('  Migration 3 finished'));
 };

--- a/migrations/3_deploy_jcash.js
+++ b/migrations/3_deploy_jcash.js
@@ -1,11 +1,15 @@
+const migrations = require('../jsroutines/migrations');
+const initConfig = require('../jsroutines/jsconfig/initConfig');
+
 global.artifacts = artifacts; // eslint-disable-line no-undef
 
-const migrations = require('../jsroutines/migrations');
-
-module.exports = (deployer) => {
+module.exports = (deployer, network, accounts) => {
   global.console.log('  Start migration 3');
 
-  deployer.then(() => migrations.executeMigration(3))
-          .then(() => migrations.verifyMigration(3))
-          .then(() => global.console.log('  Migration 3 finished'));
+  initConfig(web3, deployer, network, accounts); // eslint-disable-line no-undef
+
+  deployer
+    .then(() => migrations.executeMigration(3))
+    .then(() => migrations.verifyMigration(3))
+    .then(() => global.console.log('  Migration 3 finished'));
 };

--- a/migrations/4_unpause_jnt.js
+++ b/migrations/4_unpause_jnt.js
@@ -1,11 +1,15 @@
+const migrations = require('../jsroutines/migrations');
+const initConfig = require('../jsroutines/jsconfig/initConfig');
+
 global.artifacts = artifacts; // eslint-disable-line no-undef
 
-const migrations = require('../jsroutines/migrations');
-
-module.exports = (deployer) => {
+module.exports = (deployer, network, accounts) => {
   global.console.log('  Start migration 4');
 
-  deployer.then(() => migrations.executeMigration(4))
-          .then(() => migrations.verifyMigration(4))
-          .then(() => global.console.log('  Migration 4 finished'));
+  initConfig(web3, deployer, network, accounts); // eslint-disable-line no-undef
+
+  deployer
+    .then(() => migrations.executeMigration(4))
+    .then(() => migrations.verifyMigration(4))
+    .then(() => global.console.log('  Migration 4 finished'));
 };

--- a/migrations/4_unpause_jnt.js
+++ b/migrations/4_unpause_jnt.js
@@ -1,28 +1,11 @@
-require('babel-register');
-require('babel-polyfill');
-
 global.artifacts = artifacts; // eslint-disable-line no-undef
 
-
-const TxConfig = require('../jsroutines/jsconfig/TxConfig');
-const DeployConfig = require('../jsroutines/jsconfig/DeployConfig');
 const migrations = require('../jsroutines/migrations');
 
-
-/* Migration */
-
-module.exports = (deployer, network, accounts) => {
-  global.console.log('  Start migration');
-  global.console.log(`  Accounts: ${accounts}`);
-  global.console.log(`  Network:  ${network}`);
-
-  TxConfig.setWeb3(web3); // eslint-disable-line no-undef
-  TxConfig.setNetworkType(network);
-
-  DeployConfig.setDeployer(deployer);
-  DeployConfig.setAccounts(accounts);
+module.exports = (deployer) => {
+  global.console.log('  Start migration 4');
 
   deployer.then(() => migrations.executeMigration(4))
           .then(() => migrations.verifyMigration(4))
-          .then(() => global.console.log('  Migration finished'));
+          .then(() => global.console.log('  Migration 4 finished'));
 };

--- a/migrations/5_unpause_jcash.js
+++ b/migrations/5_unpause_jcash.js
@@ -1,28 +1,11 @@
-require('babel-register');
-require('babel-polyfill');
-
 global.artifacts = artifacts; // eslint-disable-line no-undef
 
-
-const TxConfig = require('../jsroutines/jsconfig/TxConfig');
-const DeployConfig = require('../jsroutines/jsconfig/DeployConfig');
 const migrations = require('../jsroutines/migrations');
 
-
-/* Migration */
-
-module.exports = (deployer, network, accounts) => {
-  global.console.log('  Start migration');
-  global.console.log(`  Accounts: ${accounts}`);
-  global.console.log(`  Network:  ${network}`);
-
-  TxConfig.setWeb3(web3); // eslint-disable-line no-undef
-  TxConfig.setNetworkType(network);
-
-  DeployConfig.setDeployer(deployer);
-  DeployConfig.setAccounts(accounts);
+module.exports = (deployer) => {
+  global.console.log('  Start migration 5');
 
   deployer.then(() => migrations.executeMigration(5))
           .then(() => migrations.verifyMigration(5))
-          .then(() => global.console.log('  Migration finished'));
+          .then(() => global.console.log('  Migration 5 finished'));
 };

--- a/migrations/5_unpause_jcash.js
+++ b/migrations/5_unpause_jcash.js
@@ -1,11 +1,15 @@
+const migrations = require('../jsroutines/migrations');
+const initConfig = require('../jsroutines/jsconfig/initConfig');
+
 global.artifacts = artifacts; // eslint-disable-line no-undef
 
-const migrations = require('../jsroutines/migrations');
-
-module.exports = (deployer) => {
+module.exports = (deployer, network, accounts) => {
   global.console.log('  Start migration 5');
 
-  deployer.then(() => migrations.executeMigration(5))
-          .then(() => migrations.verifyMigration(5))
-          .then(() => global.console.log('  Migration 5 finished'));
+  initConfig(web3, deployer, network, accounts); // eslint-disable-line no-undef
+
+  deployer
+    .then(() => migrations.executeMigration(5))
+    .then(() => migrations.verifyMigration(5))
+    .then(() => global.console.log('  Migration 5 finished'));
 };

--- a/migrations/6_setup_test_investors.js
+++ b/migrations/6_setup_test_investors.js
@@ -1,28 +1,11 @@
-require('babel-register');
-require('babel-polyfill');
-
 global.artifacts = artifacts; // eslint-disable-line no-undef
 
-
-const TxConfig = require('../jsroutines/jsconfig/TxConfig');
-const DeployConfig = require('../jsroutines/jsconfig/DeployConfig');
 const migrations = require('../jsroutines/migrations');
 
-
-/* Migration */
-
-module.exports = (deployer, network, accounts) => {
-  global.console.log('  Start migration');
-  global.console.log(`  Accounts: ${accounts}`);
-  global.console.log(`  Network:  ${network}`);
-
-  TxConfig.setWeb3(web3); // eslint-disable-line no-undef
-  TxConfig.setNetworkType(network);
-
-  DeployConfig.setDeployer(deployer);
-  DeployConfig.setAccounts(accounts);
+module.exports = (deployer) => {
+  global.console.log('  Start migration 6');
 
   deployer.then(() => migrations.executeMigration(6))
           .then(() => migrations.verifyMigration(6))
-          .then(() => global.console.log('  Migration finished'));
+          .then(() => global.console.log('  Migration 6 finished'));
 };

--- a/migrations/6_setup_test_investors.js
+++ b/migrations/6_setup_test_investors.js
@@ -1,11 +1,15 @@
+const migrations = require('../jsroutines/migrations');
+const initConfig = require('../jsroutines/jsconfig/initConfig');
+
 global.artifacts = artifacts; // eslint-disable-line no-undef
 
-const migrations = require('../jsroutines/migrations');
-
-module.exports = (deployer) => {
+module.exports = (deployer, network, accounts) => {
   global.console.log('  Start migration 6');
 
-  deployer.then(() => migrations.executeMigration(6))
-          .then(() => migrations.verifyMigration(6))
-          .then(() => global.console.log('  Migration 6 finished'));
+  initConfig(web3, deployer, network, accounts); // eslint-disable-line no-undef
+
+  deployer
+    .then(() => migrations.executeMigration(6))
+    .then(() => migrations.verifyMigration(6))
+    .then(() => global.console.log('  Migration 6 finished'));
 };

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "main": "truffle.js",
   "scripts": {
     "test": "scripts/test.sh",
-    "console": "truffle console",
-    "compile": "truffle compile",
+    "console": "./node_modules/.bin/truffle console",
+    "compile": "./node_modules/.bin/truffle compile",
+    "migrate": "./node_modules/.bin/truffle migrate",
     "coverage": "scripts/coverage.sh",
     "coveralls": "scripts/coveralls.sh",
     "lint": "npm run lint:js",


### PR DESCRIPTION
* fix public getters of `Migrations` contract
* add `initConfig` util method to prevent code duplication
* remove some redundant `await`
* update npm scripts for truffle